### PR TITLE
Fix comments in php/templates/*.tpl

### DIFF
--- a/ansible/roles/php/templates/php-fpm.tpl
+++ b/ansible/roles/php/templates/php-fpm.tpl
@@ -1,33 +1,32 @@
-#SETTING CONFIGURATION: pid ###############
+; SETTING CONFIGURATION: pid ###############
 pid = {{ php_run }}.pid
 
-#SETTING CONFIGURATION: error_log ###############
+; SETTING CONFIGURATION: error_log ###############
 error_log = /var/log/{{ php.version }}-fpm.log
 
-#SETTING CONFIGURATION: syslog.facility ###############
+; SETTING CONFIGURATION: syslog.facility ###############
 syslog.facility = {{ php.config.fpm.syslog_facility }}
 
-#SETTING CONFIGURATION: syslog.ident ###############
+; SETTING CONFIGURATION: syslog.ident ###############
 syslog.ident = {{ php.config.fpm.syslog_ident }}
 
-#SETTING CONFIGURATION: log_level ###############
+; SETTING CONFIGURATION: log_level ###############
 log_level = {{ php.config.fpm.log_level }}
 
-#SETTING CONFIGURATION: emergency_restart_threshold ###############
+; SETTING CONFIGURATION: emergency_restart_threshold ###############
 emergency_restart_threshold = {{ php.config.fpm.emergency_restart_threshold }}
 
-#SETTING CONFIGURATION: emergency_restart_interval ###############
+; SETTING CONFIGURATION: emergency_restart_interval ###############
 emergency_restart_interval = {{ php.config.fpm.emergency_restart_interval }}
 
-#SETTING CONFIGURATION: process_control_timeout ###############
+; SETTING CONFIGURATION: process_control_timeout ###############
 process_control_timeout = {{ php.config.fpm.process_control_timeout }}
 
-#SETTING CONFIGURATION: process.max ###############
+; SETTING CONFIGURATION: process.max ###############
 process.max = {{ php.config.fpm.process_max }}
 
-#SETTING CONFIGURATION: daemonize ###############
+; SETTING CONFIGURATION: daemonize ###############
 daemonize = {{ php.config.fpm.daemonize }}
 
-
-#POOL DIRECTORY LOCATION
+; POOL DIRECTORY LOCATION
 include={{ php_path }}/fpm/pool.d/*.conf

--- a/ansible/roles/php/templates/pool.tpl
+++ b/ansible/roles/php/templates/pool.tpl
@@ -1,5 +1,5 @@
 [www]
-###### Base Pool Configuration
+; Base Pool Configuration
 user = {{ php.config.pool.user }}
 group = {{ php.config.pool.group }}
 listen = {{ php_run }}.sock
@@ -8,7 +8,7 @@ listen.owner = {{ php.config.pool.listen_owner }}
 listen.group = {{ php.config.pool.listen_group }}
 listen.mode = {{ php.config.pool.listen_mode }}
 listen.backlog = 65536
-###### PM Configuration
+; PM Configuration
 pm = {{ php.config.pool.pm }}
 pm.max_children = {{ php.config.pool.pm_max_children }}
 pm.start_servers = {{ php.config.pool.pm_start_servers }}
@@ -17,16 +17,16 @@ pm.max_spare_servers = {{ php.config.pool.pm_max_spare_servers }}
 pm.process_idle_timeout = {{ php.config.pool.pm_process_idle_timeout }}
 pm.max_requests = {{ php.config.pool.pm_max_requests }}
 pm.status_path = /status
-###### Ping Status
+; Ping Status
 ping.path = /ping
 ping.response = /pong
-###### Logging
+; Logging
 access.format = %R - %u %t "%m %r" %s
 request_slowlog_timeout = 0
 request_terminate_timeout = 0
 access.log = /var/log/php-fpm_access.log
 slowlog = /var/log/php-fpm_slow.log
-###### Misc
+; Misc
 chdir = /
 chroot =
 catch_workers_output = no


### PR DESCRIPTION
For php-fpm7+ t's not allowed to use a hash-sign for comments.
See https://bugs.php.net/bug.php?id=70059